### PR TITLE
Add centos and container tools shortnames

### DIFF
--- a/shortames.conf
+++ b/shortames.conf
@@ -1,4 +1,10 @@
 [aliases]
+  # centos
+  "centos" = "registry.centos.org/centos"
+  # containers
+  "skopeo" = "quay.io/skopeo/stable"
+  "buildah" = "quay.io/buildah/stable"
+  "podman" = "quay.io/podman/stable"
   # docker
   "alpine" = "docker.io/alpine"
   "docker" = "docker.io/library/docker"


### PR DESCRIPTION
Add centos container image shortname.

Default container tools podman, skopeo, buildah to the stable
container images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>