### PR TITLE
doc: a series of changes for mosly minor typos, language tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ When tools like [Podman][podman-gh] or [Docker][[docker-cli-gh]] pull container 
 short names like `fedora` or `alpine` rather then fully specified image names
 `registry.fedoraproject.org/fedora` and `docker.io/alpine`, respectively. In
 container engines that allow you to specify more then a single registry for
-storing container images, using short names can lead to ambiguity. Imagine
-that I have two registries defined and both container an image names foobar.
+storing container images, using short names can lead to ambiguity.
 
-Now if I specify foobar, I am not sure which image I will get. There is potential for malicious parties to take advantage of this by spoofing images and tricking users
-into pulling them.
+Imagine that I have two registries defined and both contain an image named
+"foobar". Now if I specify `foobar`, I am not sure which image I will
+get. There is potential for malicious parties to take advantage of this by
+spoofing images and tricking users into pulling them.
 
 We are building into these container engine tools the ability to use short name
 aliases to help mitigate the risk of pulling the wrong image, especially when

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ being replaced with a right-hand value. Short-name aliases can now be
 configured in the 'registries.conf' file as follows:
 
 ```
-unqualified-search-registries=[“registry.fedoraproject.org”, “docker.io”]
+unqualified-search-registries=["registry.fedoraproject.org", "docker.io"]
 
 [aliases]
-“fedora”=”registry.fedoraproject.org/fedora”
+"fedora"="registry.fedoraproject.org/fedora"
 ```
 
 All aliases must be specified in the new “aliases” table. Using the upper

--- a/README.md
+++ b/README.md
@@ -30,26 +30,26 @@ unqualified-search-registries=["registry.fedoraproject.org", "docker.io"]
 "fedora"="registry.fedoraproject.org/fedora"
 ```
 
-All aliases must be specified in the new “aliases” table. Using the upper
-registries.conf file, Podman will resolve “fedora” immediately and securely to
+All aliases must be specified in the new “aliases” table. Using the above
+'registries.conf' file, Podman will resolve “fedora” immediately and securely to
 “registry.fedoraproject.org/fedora”. We are currently assembling a public list
 of short-name aliases that can be used across the community. Multiple Linux
-distributions and companies have expressed interest in collaborating the
+distributions and companies have expressed interest in collaborating with the
 container engines, to help registry their images.
 
 ## Goal
 
 The goal of this REPO is to gather a list of shortnames from the community, to
-allow distributions to ship them in there distributions. The idea is this list
-could be added to the default registries.conf file shipped by a distro.
+allow distributions to ship them in their distributions. The idea is this list
+could be added to the default 'registries.conf' file shipped by a distro.
 
 This list is in the open to guarantee fairness.  We do not want this to be a
 free for all land grab, so we will base the list of images on well images
 at well known registries and distributions.
 
 In the case of a conflicts, we will base the shortname on the original source of
-the image.  For example if the Fedora image is available at docker.io as well
-as registry.fedoraproject.org, we will grab it from fedoraproject.
+the image.  For example if the Fedora image is available at 'docker.io' as well
+as at 'registry.fedoraproject.org', we will grab it from fedoraproject.
 
 I am sure over time their might be further rules designed if this turns out to
 be a problem.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 When tools like Podman or Docker pull container images, users prefer to use
 short names like `fedora` or `alpine` rather then fully specified image names
-registry.fedoraproject.org/fedora and docker.io/alpine respectively. In
+`registry.fedoraproject.org/fedora` and `docker.io/alpine`, respectively. In
 container engines that allow you to specify more then a single registry for
 storing container images, using short names can lead to ambiguity. Imageine
 that I have two registries defined and both container an image names foobar.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is a short name
 
-When tools like Podman or Docker pull container images, users prefer to use
+When tools like [Podman][podman-gh] or [Docker][[docker-cli-gh]] pull container images, users prefer to use
 short names like `fedora` or `alpine` rather then fully specified image names
 `registry.fedoraproject.org/fedora` and `docker.io/alpine`, respectively. In
 container engines that allow you to specify more then a single registry for
@@ -65,3 +65,6 @@ your case on why your shortname should replace the existing short names.
 ## Contact
 
 - IRC: #[containers](irc://irc.freenode.net:6667/#containers) on freenode.net
+
+[podman-gh]:      https://github.com/containers/podman  "GitHub: containers/podman"
+[docker-cli-gh]:  https://github.com/docker/cli         "GitHub: docker/cli"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ When tools like [Podman][podman-gh] or [Docker][[docker-cli-gh]] pull container 
 short names like `fedora` or `alpine` rather then fully specified image names
 `registry.fedoraproject.org/fedora` and `docker.io/alpine`, respectively. In
 container engines that allow you to specify more then a single registry for
-storing container images, using short names can lead to ambiguity. Imageine
+storing container images, using short names can lead to ambiguity. Imagine
 that I have two registries defined and both container an image names foobar.
 
 Now if I specify foobar, I am not sure which image I will get. There is potential for malicious parties to take advantage of this by spoofing images and tricking users
 into pulling them.
 
-We are building into these contaienr engine tools the ability to use short name
+We are building into these container engine tools the ability to use short name
 aliases to help mitigate the risk of pulling the wrong image, especially when
 the image is a well known short name.
 
@@ -34,7 +34,7 @@ registries.conf file, Podman will resolve “fedora” immediately and securely 
 “registry.fedoraproject.org/fedora”. We are currently assembling a public list
 of short-name aliases that can be used across the community. Multiple Linux
 distributions and companies have expressed interest in collaborating the
-containe engines, to help registry their images.
+container engines, to help registry their images.
 
 ## Goal
 
@@ -50,10 +50,10 @@ In the case of a conflicts, we will base the shortname on the original source of
 the image.  For example if the Fedora image is available at docker.io as well
 as registry.fedoraproject.org, we will grab it from fedoraproject.
 
-I am sure over time their might be futher rules designed if this turns out to
+I am sure over time their might be further rules designed if this turns out to
 be a problem.
 
-Of course distributions are always free to make shanges to this list if/when
+Of course distributions are always free to make changes to this list if/when
 they ship it.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ We are building into these container engine tools the ability to use short name
 aliases to help mitigate the risk of pulling the wrong image, especially when
 the image is a well known short name.
 
-Similar to aliases in BASH, a short-name alias has a left-hand name that is
+Similar to aliases in shells such as Bash, a short-name alias has a left-hand name that is
 being replaced with a right-hand value. Short-name aliases can now be
-configured in the registries.conf file as follows:
+configured in the 'registries.conf' file as follows:
 
 ```
 unqualified-search-registries=[“registry.fedoraproject.org”, “docker.io”]


### PR DESCRIPTION
This PR contains changes that fix minor spelling or word-choice typos, adjusts the string quote chars in the example config file to allow them to parse as valid TOML, and adds a few links to mentioned projects.