### PR TITLE
doc: README.md: markdown: fix one busted link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is a short name
 
-When tools like [Podman][podman-gh] or [Docker][[docker-cli-gh]] pull container images, users prefer to use
+When tools like [Podman][podman-gh] or [Docker][docker-cli-gh] pull container images, users prefer to use
 short names like `fedora` or `alpine` rather then fully specified image names
 `registry.fedoraproject.org/fedora` and `docker.io/alpine`, respectively. In
 container engines that allow you to specify more then a single registry for


### PR DESCRIPTION
Hey Folks,

This is a follow-up to PR #14 from last night. I just noticed that commit 9d5f789e42b accidentally introduced an extra level of braces in the markdown for one of the links, which prevents it from being parsed correctly. This PR fixes it. Apologies for the churn,

-Al
