### PR TITLE
Add openSUSE Tumbleweed containers using the DNF package manager

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -16,9 +16,13 @@
   "fedora" = "registry.fedoraproject.org/fedora"
   # openSUSE
   "opensuse/tumbleweed" = "registry.opensuse.org/opensuse/tumbleweed"
+  "opensuse/tumbleweed-dnf" = "registry.opensuse.org/opensuse/tumbleweed-dnf"
+  "opensuse/tumbleweed-microdnf" = "registry.opensuse.org/opensuse/tumbleweed-microdnf"
   "opensuse/leap" = "registry.opensuse.org/opensuse/leap"
   "opensuse/busybox" = "registry.opensuse.org/opensuse/busybox"
   "tumbleweed" = "registry.opensuse.org/opensuse/tumbleweed"
+  "tumbleweed-dnf" = "registry.opensuse.org/opensuse/tumbleweed-dnf"
+  "tumbleweed-microdnf" = "registry.opensuse.org/opensuse/tumbleweed-microdnf"
   "leap" = "registry.opensuse.org/opensuse/leap"
   "tw-busybox" = "registry.opensuse.org/opensuse/busybox"
   # SUSE


### PR DESCRIPTION
These shortnames make it easy to access the alternative openSUSE Tumbleweed containers using DNF or Micro DNF package managers instead of Zypper.