### PR TITLE
Switch CentOS to quay

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -1,6 +1,6 @@
 [aliases]
   # centos
-  "centos" = "registry.centos.org/centos"
+  "centos" = "quay.io/centos/centos"
   # containers
   "skopeo" = "quay.io/skopeo/stable"
   "buildah" = "quay.io/buildah/stable"


### PR DESCRIPTION
The CentOS team is now publishing CentOS Linux and CentOS Stream container images to quay.io.

https://lists.centos.org/pipermail/centos-devel/2021-February/076503.html

Signed-off-by: Carl George <carl@george.computer>