### PR TITLE
[oraclelinux] Switch to the official Oracle Linux image

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -54,7 +54,7 @@
   # Ubuntu
   "ubuntu" = "docker.io/library/ubuntu"
   # Oracle Linux
-  "oraclelinux" = "container-registry.oracle.com/os/oraclelinux"
+  "oraclelinux" = "docker.io/library/oraclelinux"
   # busybox
   "busybox" = "docker.io/library/busybox"
   # php


### PR DESCRIPTION
Oracle Container Registry does not yet support manifest-lists or
OCI image indexes, so it only has the linux/amd64 platform image.
Until OCR does have this support, using the Docker Hub image will
ensure that users on both linux/amd64 and linux/arm64/v8 can
pull the Oracle Linux image.

Signed-off-by: Avi Miller <avi.miller@oracle.com>