### PR TITLE
Add openSUSE Leap containers using the DNF package manager

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -24,6 +24,8 @@
   "tumbleweed-dnf" = "registry.opensuse.org/opensuse/tumbleweed-dnf"
   "tumbleweed-microdnf" = "registry.opensuse.org/opensuse/tumbleweed-microdnf"
   "leap" = "registry.opensuse.org/opensuse/leap"
+  "leap-dnf" = "registry.opensuse.org/opensuse/leap-dnf"
+  "leap-microdnf" = "registry.opensuse.org/opensuse/leap-microdnf"
   "tw-busybox" = "registry.opensuse.org/opensuse/busybox"
   # SUSE
   "suse/sle15" = "registry.suse.com/suse/sle15"


### PR DESCRIPTION
These shortnames make it easy to access the alternative openSUSE
Leap containers using DNF or Micro DNF package managers instead
of Zypper.