### PR TITLE
[oraclelinux] Switch back to the official Oracle Linux image

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -56,7 +56,7 @@
   # Ubuntu
   "ubuntu" = "docker.io/library/ubuntu"
   # Oracle Linux
-  "oraclelinux" = "docker.io/library/oraclelinux"
+  "oraclelinux" = "container-registry.oracle.com/os/oraclelinux"
   # busybox
   "busybox" = "docker.io/library/busybox"
   # php


### PR DESCRIPTION
Oracle Container Registry now has manifest lists for the Oracle
Linux images, so this reverts commit e4521b060537c2b8b456ca4047f164309bedde89 and switches
back to the official images from an Oracle owned source.

Signed-off-by: Avi Miller <avi.miller@oracle.com>