### PR TITLE
README.md: Change contact IRC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The configuration file is intended to be shipped in the `/etc/containers/registr
 
 ## Contact
 
-- IRC: #[containers](irc://irc.freenode.net:6667/#containers) on freenode.net
+- IRC: #[containers](ircs://irc.libera.chat:6697/#containers) on libera.chat ([Webchat](https://web.libera.chat/))
 
 [podman-gh]:      https://github.com/containers/podman  "GitHub: containers/podman"
 [docker-cli-gh]:  https://github.com/docker/cli         "GitHub: docker/cli"


### PR DESCRIPTION
Hope this is the correct info.

I've picked the URI with `ircs://` and TLS port 6697. Let me know if there are any good reasons to use the plaintext port here. 