### PR TITLE
Add Kali Linux to shortnames

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -58,6 +58,12 @@
   "rockylinux" = "docker.io/library/rockylinux"
   # Debian
   "debian" = "docker.io/library/debian"
+  # Kali Linux
+  "kali-bleeding-edge" = "docker.io/kalilinux/kali-bleeding-edge"
+  "kali-dev" = "docker.io/kalilinux/kali-dev"
+  "kali-experimental" = "docker.io/kalilinux/kali-experimental"
+  "kali-last-release" = "docker.io/kalilinux/kali-last-release"
+  "kali-rolling" = "docker.io/kalilinux/kali-rolling"
   # Ubuntu
   "ubuntu" = "docker.io/library/ubuntu"
   # Oracle Linux


### PR DESCRIPTION
For reference:
- https://www.kali.org/docs/containers/official-kalilinux-docker-images/
- https://gitlab.com/kalilinux/build-scripts/kali-docker/-/issues/38

Signed-off-by: Arnaud Rebillout <arnaudr@kali.org>