### PR TITLE
add hello podman image and point hello-world to it

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -10,11 +10,12 @@
   "skopeo" = "quay.io/skopeo/stable"
   "buildah" = "quay.io/buildah/stable"
   "podman" = "quay.io/podman/stable"
+  "hello" = "quay.io/podman/hello"
+  "hello-world" = "quay.io/podman/hello"
   # docker
   "alpine" = "docker.io/library/alpine"
   "docker" = "docker.io/library/docker"
   "registry" = "docker.io/library/registry"
-  "hello-world" = "docker.io/library/hello-world"
   "swarm" = "docker.io/library/swarm"
   # Fedora
   "fedora-minimal" = "registry.fedoraproject.org/fedora-minimal"


### PR DESCRIPTION
The quay.io/podman/hello image should now be available for all arches.[1]
Lets add it to the shortnames.conf.

Also change the hello-world to point to it instead of the docker.io image.
shortnames.conf is only used in podman and other related containers
projects but not docker so it makes more sense to point users to the
podman image IMO.

[1] https://github.com/containers/podman/issues/13364