### PR TITLE
Point archlinux to docker.io/library/archlinux

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -3,7 +3,7 @@
   "almalinux" = "docker.io/library/almalinux"
   "almalinux-minimal" = "docker.io/library/almalinux-minimal"
   # Arch Linux
-  "archlinux" = "docker.io/archlinux/archlinux"
+  "archlinux" = "docker.io/library/archlinux"
   # centos
   "centos" = "quay.io/centos/centos"
   # containers


### PR DESCRIPTION
Arch Linux reached "docker official image" status in the meantime, `docker run archlinux` and `podman run archlinux` currently resolves to two different images:

```
% docker run -it --rm archlinux pacman -Q | sha256sum -
e269d8b1b5a27ad7e052601cf2de77ce858fd08a397946f627b833129bfaa4a3  -
% podman run -it --rm archlinux pacman -Q | sha256sum -
0e76a2db5b5a75d509b9452857d413e35027e1627d97077da89bfb276ed1b91e  - 
```