### PR TITLE
Add missing rust alias

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -111,5 +111,7 @@
   "php" = "docker.io/library/php"
   # python
   "python" = "docker.io/library/python"
+  # rust
+  "rust" = "docker.io/library/rust"
   # node
   "node" = "docker.io/library/node"


### PR DESCRIPTION
```
% docker run --rm rust cargo -V 
cargo 1.65.0 (4bc8f24d3 2022-10-20)
% podman run --rm rust cargo -V 
Error: short-name "rust" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```