### PR TITLE
Add Amazon Linux

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -2,6 +2,8 @@
   # almalinux
   "almalinux" = "docker.io/library/almalinux"
   "almalinux-minimal" = "docker.io/library/almalinux-minimal"
+  # Amazon Linux
+  "amazonlinux" = "public.ecr.aws/amazonlinux/amazonlinux"
   # Arch Linux
   "archlinux" = "docker.io/library/archlinux"
   # centos


### PR DESCRIPTION
The Amazon Linux documentation advises users to pull the container image with this command:

```
docker pull public.ecr.aws/amazonlinux/amazonlinux:latest
```

It also mentions pulling the image from Docker Hub, but it mentioned the ECR name first so it's probably safe to consider that the default.

https://docs.aws.amazon.com/AmazonECR/latest/userguide/amazon_linux_container_image.html
https://gallery.ecr.aws/amazonlinux/amazonlinux