### PR TITLE
Add Grafana Labs OSS projects

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -123,3 +123,12 @@
   "rust" = "docker.io/library/rust"
   # node
   "node" = "docker.io/library/node"
+  # Grafana Labs
+  "grafana/agent" = "docker.io/grafana/agent"
+  "grafana/grafana" = "docker.io/grafana/grafana"
+  "grafana/k6" = "docker.io/grafana/k6"
+  "grafana/loki" = "docker.io/grafana/loki"
+  "grafana/mimir" = "docker.io/grafana/mimir"
+  "grafana/oncall" = "docker.io/grafana/oncall"
+  "grafana/pyroscope" = "docker.io/grafana/pyroscope"
+  "grafana/tempo" = "docker.io/grafana/tempo"


### PR DESCRIPTION
This adds shortname aliases for the major open source projects maintained by Grafana Labs

Let me know if there's more to change to get this shipped!