### PR TITLE
Add shortname for golang

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -132,6 +132,8 @@
   "oraclelinux" = "container-registry.oracle.com/os/oraclelinux"
   # busybox
   "busybox" = "docker.io/library/busybox"
+  # golang
+  "golang" = "docker.io/library/golang"
   # php
   "php" = "docker.io/library/php"
   # python


### PR DESCRIPTION
```
$ sudo docker run --rm golang go version
Unable to find image 'golang:latest' locally
latest: Pulling from library/golang
[...]
Status: Downloaded newer image for golang:latest
go version go1.23.4 linux/amd64
```

```
$ podman run --rm golang go version
Error: short-name "golang" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```