### PR TITLE
add unprefixed bci-aliases for the BCI base containers

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -62,9 +62,13 @@
   "sles12sp5" = "registry.suse.com/suse/sles12sp5"
   "sles12sp4" = "registry.suse.com/suse/sles12sp4"
   "sles12sp3" = "registry.suse.com/suse/sles12sp3"
+  "bci-base" = "registry.suse.com/bci/bci-base"
   "bci/bci-base" = "registry.suse.com/bci/bci-base"
+  "bci-micro" = "registry.suse.com/bci/bci-micro"
   "bci/bci-micro" = "registry.suse.com/bci/bci-micro"
+  "bci-minimal" = "registry.suse.com/bci/bci-minimal"
   "bci/bci-minimal" = "registry.suse.com/bci/bci-minimal"
+  "bci-busybox" = "registry.suse.com/bci/bci-busybox"
   "bci/bci-busybox" = "registry.suse.com/bci/bci-busybox"
   # Red Hat Enterprise Linux
   "rhel" = "registry.access.redhat.com/rhel"


### PR DESCRIPTION
typing bci/bci-base seems redundant, bci-base is enough.