### PR TITLE
Add short name for curl

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -155,3 +155,5 @@
   "grafana/oncall" = "docker.io/grafana/oncall"
   "grafana/pyroscope" = "docker.io/grafana/pyroscope"
   "grafana/tempo" = "docker.io/grafana/tempo"
+  # curl
+  "curl" = "quay.io/curl/curl"


### PR DESCRIPTION
The official curl images are hosted on quay.io: <https://github.com/curl/curl-container>