### PR TITLE
Add shortname for nginx

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -157,3 +157,5 @@
   "grafana/tempo" = "docker.io/grafana/tempo"
   # curl
   "curl" = "quay.io/curl/curl"
+  # nginx
+  "nginx" = "docker.io/library/nginx"


### PR DESCRIPTION
nginx image is officially hosted on Docker Hub: https://github.com/nginx/docker-nginx