### PR TITLE
Add alias for Fedora ELN

### DIFF
--- a/shortnames.conf
+++ b/shortnames.conf
@@ -20,6 +20,7 @@
   "registry" = "docker.io/library/registry"
   "swarm" = "docker.io/library/swarm"
   # Fedora
+  "eln" = "registry.fedoraproject.org/eln"
   "fedora-bootc" = "registry.fedoraproject.org/fedora-bootc"
   "fedora-minimal" = "registry.fedoraproject.org/fedora-minimal"
   "fedora" = "registry.fedoraproject.org/fedora"


### PR DESCRIPTION
Fedora also has an ELN variant. Its image exists at registry.fedoraproject.org/eln:latest, redirectring to quay.io/fedora/eln:latest.

This patch adds the "eln" alias.

Resolves: #71