### PR TITLE
shortnames.conf: drop tumbleweed-microdnf and trivy aliases

### DIFF
--- a/inspect-images.py
+++ b/inspect-images.py
@@ -22,17 +22,16 @@ def get_images_to_inspect() -> list[str]:
     ]
 
 
-async def inspect_image(shortname: str) -> None:
+async def inspect_image(url: str) -> tuple[str, str] | None:
     proc = await asyncio.create_subprocess_shell(
-        cmd := f"skopeo inspect --override-arch amd64 docker://{shortname}",
+        f"skopeo inspect --override-arch amd64 docker://{url}",
         stderr=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = (out.decode() for out in await proc.communicate())
+    _, stderr = (out.decode() for out in await proc.communicate())
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"{cmd} failed with exit code {proc.returncode}, {stdout=}, {stderr=}"
-        )
+        return url, stderr.strip()
+    return None
 
 
 if __name__ == "__main__":
@@ -71,11 +70,15 @@ if __name__ == "__main__":
     shutil.copy("shortnames.conf", shortnames_dest)
 
     async def run():
-        tasks = []
-        for shortname in get_images_to_inspect():
-            tasks.append(inspect_image(shortname))
-
-        await asyncio.gather(*tasks)
+        results = await asyncio.gather(
+            *[inspect_image(url) for url in get_images_to_inspect()]
+        )
+        failures = [r for r in results if r is not None]
+        if failures:
+            print("Failed to inspect the following images:")
+            for url, err in failures:
+                print(f"  {url}\n    {err}")
+            raise SystemExit(1)
 
     try:
         asyncio.run(run())

--- a/inspect-images.py
+++ b/inspect-images.py
@@ -24,7 +24,7 @@ def get_images_to_inspect() -> list[str]:
 
 async def inspect_image(shortname: str) -> None:
     proc = await asyncio.create_subprocess_shell(
-        cmd := f"skopeo inspect docker://{shortname}",
+        cmd := f"skopeo inspect --override-arch amd64 docker://{shortname}",
         stderr=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
     )
@@ -70,17 +70,15 @@ if __name__ == "__main__":
         shutil.copy(shortnames_dest, f"{shortnames_dest}.back")
     shutil.copy("shortnames.conf", shortnames_dest)
 
+    async def run():
+        tasks = []
+        for shortname in get_images_to_inspect():
+            tasks.append(inspect_image(shortname))
+
+        await asyncio.gather(*tasks)
+
     try:
-        loop = asyncio.get_event_loop()
-
-        async def run():
-            tasks = []
-            for shortname in get_images_to_inspect():
-                tasks.append(inspect_image(shortname))
-
-            await asyncio.gather(*tasks)
-
-        loop.run_until_complete(run())
+        asyncio.run(run())
 
     finally:
         os.remove(shortnames_dest)

--- a/shortnames.conf
+++ b/shortnames.conf
@@ -29,12 +29,10 @@
   # openSUSE
   "opensuse/tumbleweed" = "registry.opensuse.org/opensuse/tumbleweed"
   "opensuse/tumbleweed-dnf" = "registry.opensuse.org/opensuse/tumbleweed-dnf"
-  "opensuse/tumbleweed-microdnf" = "registry.opensuse.org/opensuse/tumbleweed-microdnf"
   "opensuse/leap" = "registry.opensuse.org/opensuse/leap"
   "opensuse/busybox" = "registry.opensuse.org/opensuse/busybox"
   "tumbleweed" = "registry.opensuse.org/opensuse/tumbleweed"
   "tumbleweed-dnf" = "registry.opensuse.org/opensuse/tumbleweed-dnf"
-  "tumbleweed-microdnf" = "registry.opensuse.org/opensuse/tumbleweed-microdnf"
   "leap" = "registry.opensuse.org/opensuse/leap"
   "leap-dnf" = "registry.opensuse.org/opensuse/leap-dnf"
   "leap-microdnf" = "registry.opensuse.org/opensuse/leap-microdnf"
@@ -167,6 +165,3 @@
   "qubip/pq-container" = "quay.io/qubip/pq-container"
   # SonarQube
   "sonarqube" = "docker.io/library/sonarqube"
-  # Aqua Security
-  "aquasec/trivy" = "docker.io/aquasec/trivy"
-  "trivy" = "docker.io/aquasec/trivy"


### PR DESCRIPTION
The tumbleweed-microdnf image has been removed from the openSUSE
registry and the trivy image is no longer available on Docker Hub.
Remove all aliases pointing to these non-existent images.